### PR TITLE
fix setting entropy with new ldk-node version

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,17 +1,21 @@
 PODS:
-  - bdk_flutter (0.28.0):
+  - bdk_flutter (0.28.3):
     - Flutter
   - Flutter (1.0.0)
   - flutter_secure_storage (6.0.0):
     - Flutter
-  - ldk_node (0.1.0):
+  - ldk_node (0.1.1):
     - Flutter
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - bdk_flutter (from `.symlinks/plugins/bdk_flutter/ios`)
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - ldk_node (from `.symlinks/plugins/ldk_node/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
 
 EXTERNAL SOURCES:
   bdk_flutter:
@@ -22,12 +26,15 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
   ldk_node:
     :path: ".symlinks/plugins/ldk_node/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
 
 SPEC CHECKSUMS:
-  bdk_flutter: 606f35fb59c99b9894a2a80cca66f9ccc824506b
+  bdk_flutter: 8f8f084899883723cec0c1c8dd858f10ce157ecc
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
-  ldk_node: 22f8295d7ea99b61dea82fe2819057a4e3d0e1d1
+  ldk_node: be24d4856e56e08ec815629115c112b6d9cd230f
+  path_provider_foundation: eaf5b3e458fc0e5fbb9940fb09980e853fe058b8
 
 PODFILE CHECKSUM: ce13d36744da294d67f8e460dbb7aed7c09bd7f4
 

--- a/lib/blocs/lightning_node/lightning_node_bloc.dart
+++ b/lib/blocs/lightning_node/lightning_node_bloc.dart
@@ -35,10 +35,8 @@ class LightningNodeBloc extends Bloc<LightningNodeEvent, LightningNodeState> {
       final mnemonic = await _seedRepository.retrieveMnemonic();
       //final seed = await mnemonic.toLightningSeed(event.network.bdkNetwork, event.password);
       //print("seed: $seed");
-      print("mnemonic: ${mnemonic.toString()}");
       await _lightningNodeRepository.startNodeWithMnemonic(
           mnemonic: mnemonic.asString(), network: event.network);
-      print("node started");
       final nodeId = await _lightningNodeRepository.nodeId;
       emit(LightningNodeRunSuccess(network: event.network, nodeId: nodeId));
     } catch (e) {

--- a/lib/blocs/network/network_cubit.dart
+++ b/lib/blocs/network/network_cubit.dart
@@ -3,7 +3,7 @@ import 'package:lightning_node_repository/lightning_node_repository.dart';
 
 class NetworkCubit extends Cubit<Network> {
   // Default network is Regtest, at the moment of creating the NetworkCubit, another network can be set
-  NetworkCubit([Network network = Network.Regtest]) : super(network);
+  NetworkCubit([Network network = Network.regtest]) : super(network);
 
   void setNetwork(Network network) {
     emit(network);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,15 +14,16 @@ Future<void> main() async {
   final lightningNodeRepository = LightningNodeRepository();
   // Create BloCs
   final networkCubit = NetworkCubit(
-      Network.Regtest); // Change this to Network.Bitcoin in production
+      Network.regtest); // Change this to Network.Bitcoin in production
   final lightningNodeBloc = LightningNodeBloc(
     lightningNodeRepository: lightningNodeRepository,
     seedRepository: seedRepository,
   );
 
-  // Delete stored mnemonic to start with onboarding
-  // comment out to keep the already stored mnemonic
-  // await seedRepository.deleteMnemonic();
+  // @dev The following line is just for testing purposes
+  // Delete stored mnemonic to start with onboarding.
+  // Comment it out to keep the already stored mnemonic and skip onboarding.
+  await seedRepository.deleteMnemonic();
 
   runApp(App(
     seedRepository: seedRepository,

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,12 +5,10 @@
 import FlutterMacOS
 import Foundation
 
-import bdk_flutter
 import flutter_secure_storage_macos
 import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  BdkFlutterPlugin.register(with: registry.registrar(forPlugin: "BdkFlutterPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,15 +1,28 @@
 PODS:
+  - flutter_secure_storage_macos (6.1.1):
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
+  - flutter_secure_storage_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
 
 EXTERNAL SOURCES:
+  flutter_secure_storage_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
 
 SPEC CHECKSUMS:
+  flutter_secure_storage_macos: d56e2d218c1130b262bef8b4a7d64f88d7f9c9ea
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  path_provider_foundation: eaf5b3e458fc0e5fbb9940fb09980e853fe058b8
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				523D65AA68F8E98B6F660AC0 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -312,6 +313,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		523D65AA68F8E98B6F660AC0 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/packages/lightning_node_repository/lib/src/lightning_node_repository_base.dart
+++ b/packages/lightning_node_repository/lib/src/lightning_node_repository_base.dart
@@ -8,16 +8,16 @@ import 'package:path_provider/path_provider.dart';
 /// Bitcoin network enum
 enum Network {
   ///Classic Bitcoin
-  Bitcoin,
+  bitcoin,
 
   ///Bitcoin’s testnet
-  Testnet,
+  testnet,
 
   ///Bitcoin’s signet
-  Signet,
+  signet,
 
   ///Bitcoin’s regtest
-  Regtest,
+  regtest,
 }
 
 // Extension to be able to map the exposed Network enum onto ldk_node's Network enum.
@@ -25,26 +25,26 @@ enum Network {
 extension NetworkX on Network {
   ldk.Network get ldkNetwork {
     switch (this) {
-      case Network.Bitcoin:
-        return ldk.Network.Bitcoin;
-      case Network.Testnet:
-        return ldk.Network.Testnet;
-      case Network.Signet:
-        return ldk.Network.Testnet;
-      case Network.Regtest:
-        return ldk.Network.Regtest;
+      case Network.bitcoin:
+        return ldk.Network.bitcoin;
+      case Network.testnet:
+        return ldk.Network.testnet;
+      case Network.signet:
+        return ldk.Network.testnet;
+      case Network.regtest:
+        return ldk.Network.regtest;
     }
   }
 
   bdk.Network get bdkNetwork {
     switch (this) {
-      case Network.Bitcoin:
+      case Network.bitcoin:
         return bdk.Network.Bitcoin;
-      case Network.Testnet:
+      case Network.testnet:
         return bdk.Network.Testnet;
-      case Network.Signet:
+      case Network.signet:
         return bdk.Network.Testnet;
-      case Network.Regtest:
+      case Network.regtest:
         return bdk.Network.Regtest;
     }
   }
@@ -59,7 +59,7 @@ class LightningNodeRepository {
   }
 
   Future<void> startNodeWithSeedBytes(
-      {required List<int> seedBytes, Network network = Network.Regtest}) async {
+      {required List<int> seedBytes, Network network = Network.regtest}) async {
     ldk.Builder builder = await _getNodeBuilder(network: network);
     await builder.setEntropySeedBytes(
         seedBytes: ldk.U8Array64(Uint8List.fromList(seedBytes)));
@@ -68,18 +68,11 @@ class LightningNodeRepository {
   }
 
   Future<void> startNodeWithMnemonic(
-      {required String mnemonic, Network network = Network.Regtest}) async {
-    //final path = await _localPath();
-    //final dir = Directory(path);
-    //print("Path files Before: ${await dir.list().toList()}");
+      {required String mnemonic, Network network = Network.regtest}) async {
     ldk.Builder builder = await _getNodeBuilder(network: network);
-    //print("Path files after builder: ${await dir.list().toList()}");
     await builder.setEntropyBip39Mnemonic(mnemonic: mnemonic);
-    //print("Path files after entropy: ${await dir.list().toList()}");
-    //print("Source: ${builder.entropySource}");
     _node = await builder.build();
     await _node.start();
-    //print("Path files after start node: ${await dir.list().toList()}");
   }
 
   Future<void> stopNode() async {
@@ -91,34 +84,34 @@ class LightningNodeRepository {
   }
 
   Future<ldk.Builder> _getNodeBuilder(
-      {Network network = Network.Regtest}) async {
+      {Network network = Network.regtest}) async {
     final config = await _getConfig(network: network);
     ldk.Builder builder = ldk.Builder.fromConfig(config: config);
     return builder;
   }
 
-  Future<ldk.Config> _getConfig({Network network = Network.Regtest}) async {
+  Future<ldk.Config> _getConfig({Network network = Network.regtest}) async {
     // Todo: Check if config is stored in shared preferences, if not, return default config
     final config = await _getDefaultConfig(network: network);
     return config;
   }
 
   Future<ldk.Config> _getDefaultConfig(
-      {Network network = Network.Regtest}) async {
+      {Network network = Network.regtest}) async {
     String nodePath =
         await _localPath(); // Path where the node will store its data
     String esploraUrl; // Electrum RPC Api url
     ldk.SocketAddr address; // Lightning P2P listening address
     switch (network) {
-      case Network.Bitcoin:
+      case Network.bitcoin:
         address = const ldk.SocketAddr(ip: "0.0.0.0", port: 9735);
         esploraUrl = "https://blockstream.info/api";
-      case Network.Testnet:
+      case Network.testnet:
         address = const ldk.SocketAddr(ip: "0.0.0.0", port: 19735);
         esploraUrl = "https://blockstream.info/testnet/api";
-      case Network.Signet:
+      case Network.signet:
         throw UnimplementedError();
-      case Network.Regtest:
+      case Network.regtest:
         address = const ldk.SocketAddr(ip: "0.0.0.0", port: 19846);
         esploraUrl = "http://127.0.0.1:18443";
       //esploraUrl = Platform.isAndroid ? "http://10.0.2.2:3002" : "http://0.0.0.0:3002"; // Please use 10.0.2.2, instead of 0.0.0.0

--- a/packages/lightning_node_repository/pubspec.lock
+++ b/packages/lightning_node_repository/pubspec.lock
@@ -45,11 +45,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "9d8b7b96c9ec0c973330c38a17de43d844f8a3e2"
-      resolved-ref: "9d8b7b96c9ec0c973330c38a17de43d844f8a3e2"
-      url: "https://github.com/LtbLightning/bdk-flutter.git"
+      ref: "frb-to-1.77.0"
+      resolved-ref: "3f463bda45aac53e21b0ba9f28f42b4d3cd0f852"
+      url: "https://github.com/kumulynja/bdk-flutter"
     source: git
-    version: "0.28.0"
+    version: "0.28.3"
   boolean_selector:
     dependency: transitive
     description:
@@ -203,18 +203,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_rust_bridge
-      sha256: "83d4b4d2847e438eb647437c14d780f293dc2407f04854b227c18af2e6426eab"
+      sha256: c039cb7b21d11665591557c1bf1d558f8db549a260cc69d455f30443a883f95c
       url: "https://pub.dev"
     source: hosted
-    version: "1.75.1"
+    version: "1.77.1"
   freezed:
     dependency: transitive
     description:
       name: freezed
-      sha256: "2edb9ef971d0f803860ecd9084afd48c717d002141ad77b69be3e976bee7190e"
+      sha256: a9520490532087cf38bf3f7de478ab6ebeb5f68bb1eb2641546d92719b224445
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.5"
   freezed_annotation:
     dependency: transitive
     description:
@@ -291,11 +291,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: main
-      resolved-ref: a2eb6d06c30e851625633624924713cf7cc12106
+      ref: "v0.1.1"
+      resolved-ref: "0178f7bc17fcce4519a1348afe1cfdec4d288fb9"
       url: "https://github.com/LtbLightning/ldk-node-flutter"
     source: git
-    version: "0.1.0"
+    version: "0.1.1"
   logging:
     dependency: transitive
     description:

--- a/packages/lightning_node_repository/pubspec.yaml
+++ b/packages/lightning_node_repository/pubspec.yaml
@@ -7,14 +7,14 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  bdk_flutter:
+  bdk_flutter: 
     git:
-      url: https://github.com/LtbLightning/bdk-flutter.git
-      ref: 9d8b7b96c9ec0c973330c38a17de43d844f8a3e2
+      url: https://github.com/kumulynja/bdk-flutter
+      ref: frb-to-1.77.0
   ldk_node:
     git:
       url: https://github.com/LtbLightning/ldk-node-flutter
-      ref: main
+      ref: v0.1.1
   path_provider: ^2.0.15
       
 dev_dependencies:

--- a/packages/seed_repository/pubspec.yaml
+++ b/packages/seed_repository/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
 # Add regular dependencies here.
 dependencies:
   # path: ^1.8.0
-  bdk_flutter:
+  bdk_flutter: 
     git:
-      url: https://github.com/LtbLightning/bdk-flutter.git
-      ref: 9d8b7b96c9ec0c973330c38a17de43d844f8a3e2
+      url: https://github.com/kumulynja/bdk-flutter
+      ref: frb-to-1.77.0
   secure_storage_layer:
     path: ../secure_storage_layer
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -45,11 +45,11 @@ packages:
     dependency: transitive
     description:
       path: "."
-      ref: "9d8b7b96c9ec0c973330c38a17de43d844f8a3e2"
-      resolved-ref: "9d8b7b96c9ec0c973330c38a17de43d844f8a3e2"
-      url: "https://github.com/LtbLightning/bdk-flutter.git"
+      ref: "frb-to-1.77.0"
+      resolved-ref: "3f463bda45aac53e21b0ba9f28f42b4d3cd0f852"
+      url: "https://github.com/kumulynja/bdk-flutter"
     source: git
-    version: "0.28.0"
+    version: "0.28.3"
   bloc:
     dependency: transitive
     description:
@@ -275,10 +275,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_rust_bridge
-      sha256: "83d4b4d2847e438eb647437c14d780f293dc2407f04854b227c18af2e6426eab"
+      sha256: c039cb7b21d11665591557c1bf1d558f8db549a260cc69d455f30443a883f95c
       url: "https://pub.dev"
     source: hosted
-    version: "1.75.1"
+    version: "1.77.1"
   flutter_secure_storage:
     dependency: transitive
     description:
@@ -341,10 +341,10 @@ packages:
     dependency: transitive
     description:
       name: freezed
-      sha256: "73b58fe836dc05594451d8f740d97d5167886962d628b9f60a1fe945aa0a891f"
+      sha256: a9520490532087cf38bf3f7de478ab6ebeb5f68bb1eb2641546d92719b224445
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.5"
   freezed_annotation:
     dependency: transitive
     description:
@@ -429,11 +429,11 @@ packages:
     dependency: transitive
     description:
       path: "."
-      ref: main
-      resolved-ref: a2eb6d06c30e851625633624924713cf7cc12106
+      ref: "v0.1.1"
+      resolved-ref: "0178f7bc17fcce4519a1348afe1cfdec4d288fb9"
       url: "https://github.com/LtbLightning/ldk-node-flutter"
     source: git
-    version: "0.1.0"
+    version: "0.1.1"
   lightning_node_repository:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Setting the entropy with a mnemonic or seed bytes did not work with the previous ldk node version, now it does with v0.1.1 hich is included here. Also bdk-flutter is updated to be compatible.